### PR TITLE
Ensure entire SIP body is read

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
+        <version>3.2.0</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -155,6 +156,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.1.1</version>
         <configuration>
           <additionalparam>-Xdoclint:none</additionalparam>
         </configuration>
@@ -183,7 +185,7 @@
                   <version>[1.7.0,)</version>
                 </requireJavaVersion>
                 <requireMavenVersion>
-                  <version>[3.0.5,3.1.2)</version>
+                  <version>[3.0.5,3.6.2)</version>
                 </requireMavenVersion>
               </rules>
             </configuration>

--- a/sipstack-netty-codec-sip/src/main/java/io/sipstack/netty/codec/sip/RawMessage.java
+++ b/sipstack-netty-codec-sip/src/main/java/io/sipstack/netty/codec/sip/RawMessage.java
@@ -114,7 +114,7 @@ public final class RawMessage {
          * bail on the 'T', then we would once again move over to the state
          * {@link #GET_HEADERS}.
          */
-        IS_CONTENT_LENGTH_HEADER, CONSUME_COLON, CONSUME_LWS, EXPECT_COLON, CONSUME_DIGIT;
+        IS_CONTENT_LENGTH_HEADER, CONSUME_COLON, CONSUME_LWS, EXPECT_COLON, CONSUME_DIGIT, END_OF_HEADERS;
     }
 
     /**
@@ -172,7 +172,7 @@ public final class RawMessage {
             writeToHeaders(b);
             if (doubleCRLF(b)) {
                 if (getContentLength() > 0) {
-                    this.state = State.GET_PAYLOAD;
+                    this.state = State.END_OF_HEADERS;
                 } else {
                     this.state = State.GET_PAYLOAD;
                     this.done = true;
@@ -221,6 +221,10 @@ public final class RawMessage {
             writeToPayload(b);
             if (payloadCompleted()) {
                 this.done = true;
+            }
+        } else if (this.state == State.END_OF_HEADERS) {
+            if (isCRLF(b)) {
+                this.state = State.GET_PAYLOAD;
             }
         } else {
             throw new RuntimeException("Unknown state " + this.state);

--- a/sipstack-netty-codec-sip/src/test/io/sipstack/netty/codec/sip/RawMessageTest.java
+++ b/sipstack-netty-codec-sip/src/test/io/sipstack/netty/codec/sip/RawMessageTest.java
@@ -1,0 +1,83 @@
+package io.sipstack.netty.codec.sip;
+
+import io.pkts.buffer.Buffer;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+public class RawMessageTest {
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+                {"OPTIONS sip:pfry@127.0.0.1;transport=tcp SIP/2.0\r\n" +
+                        "Via: SIP/2.0/TCP 127.0.0.1:1337;rport;branch=z9hG4k;alias\r\n" +
+                        "Max-Forwards: 70\r\n" +
+                        "From: <sip:tleela@127.0.01>;tag=1018302\r\n" +
+                        "To: <sip:pfry@127.0.0.1>\r\n" +
+                        "Call-ID: a-long-call-id\r\n" +
+                        "CSeq: 1 OPTIONS\r\n" +
+                        "Content-Type: text/plain\r\n" +
+                        "Content-Length:    10\r\n" +
+                        "\r\n" +
+                        "I love you",
+                        "I love you"
+                },
+                {"OPTIONS sip:pfry@127.0.0.1;transport=tcp SIP/2.0\r\n" +
+                        "Via: SIP/2.0/TCP 127.0.0.1:1337;rport;branch=z9hG4k;alias\r\n" +
+                        "Max-Forwards: 70\r\n" +
+                        "From: <sip:tleela@127.0.01>;tag=1018302\r\n" +
+                        "To: <sip:pfry@127.0.0.1>\r\n" +
+                        "Call-ID: a-long-call-id\r\n" +
+                        "CSeq: 1 OPTIONS\r\n" +
+                        "Content-Type: text/plain\r\n" +
+                        "Content-Length:    0\r\n" +
+                        "\r\n",
+                        null
+                }
+        });
+    }
+
+    private final String input;
+    private final String expected;
+
+    public RawMessageTest(String input, String expected) {
+        this.input = input;
+        this.expected = expected;
+    }
+
+    @Test
+    public void testPayloadParsing() throws IOException, MaxMessageSizeExceededException {
+        RawMessage rawMessage = convertToRawMessage(input);
+        assertEquals(expected, extractPayload(rawMessage));
+    }
+
+    private RawMessage convertToRawMessage(String msg) throws IOException, MaxMessageSizeExceededException {
+        ByteArrayInputStream bytes = new ByteArrayInputStream(msg.getBytes());
+        RawMessage rawMessage = new RawMessage(SipMessageStreamDecoder.MAX_ALLOWED_INITIAL_LINE_SIZE,
+                SipMessageStreamDecoder.MAX_ALLOWED_HEADERS_SIZE, SipMessageStreamDecoder.MAX_ALLOWED_CONTENT_LENGTH);
+        int b;
+        while (!rawMessage.isComplete() && (b = bytes.read()) != -1) {
+            rawMessage.write((byte) b);
+        }
+        return rawMessage;
+    }
+
+    private String extractPayload(RawMessage msg) {
+        Buffer payload = msg.getPayload();
+        if (payload != null) {
+            return payload.toString();
+        } else {
+            return null;
+        }
+    }
+
+}


### PR DESCRIPTION
RFC 3261 states that the size of the message body does not include the
CRLF separating header fields and the body. However, the CRLF was not
being skipped, and instead was being included in the payload of the
RawMessage. This had the effect of cutting off the last two characters
of the message body.